### PR TITLE
refactor: remove unused connection prop from components for cleaner code

### DIFF
--- a/src/components/BulkDataStudio.tsx
+++ b/src/components/BulkDataStudio.tsx
@@ -23,7 +23,7 @@ interface BulkDataStudioProps {
   connection: ToolBoxAPI.DataverseConnection | null;
   dvSvc: dvService;
   vm: ViewModel;
-  utils: utilService; 
+  utils: utilService;
   onLog: (message: string, type?: "info" | "success" | "warning" | "error") => void;
 }
 
@@ -61,7 +61,7 @@ export const BulkDataStudio = observer((props: BulkDataStudioProps): React.JSX.E
             </div>
           </Allotment.Pane>
           <Allotment.Pane minSize={300}>
-            <DataUpdate connection={connection} dvSvc={dvSvc} vm={vm} utils={utils} onLog={onLog} />
+            <DataUpdate dvSvc={dvSvc} vm={vm} utils={utils} onLog={onLog} />
           </Allotment.Pane>
         </Allotment>
       </div>

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -27,7 +27,6 @@ ModuleRegistry.registerModules([
 ]);
 
 import { SelectionValue, ViewModel } from "../model/ViewModel";
-import { dvService } from "../utils/dataverseService";
 import { utilService } from "../utils/utils";
 const agTheme = themeQuartz.withParams({
   headerHeight: "30px",
@@ -89,8 +88,8 @@ export const DataGrid = observer((props: DataGridProps): React.JSX.Element => {
   }, []);
   return (
     <div style={{ width: "100%", height: "85vh" }}>
-      
-      <AgGridReact suppressFieldDotNotation
+      <AgGridReact
+        suppressFieldDotNotation
         rowData={vm.data}
         columnDefs={cols}
         theme={agTheme}

--- a/src/components/DataUpdate.tsx
+++ b/src/components/DataUpdate.tsx
@@ -11,7 +11,6 @@ import { UpdateAddField } from "./UpdateAddField";
 import { TouchDialog, UpdateDialog } from "./UpdateDialog";
 import { utilService } from "../utils/utils";
 interface DataUpdateProps {
-  connection: ToolBoxAPI.DataverseConnection | null;
   dvSvc: dvService;
   vm: ViewModel;
   utils: utilService;
@@ -19,7 +18,7 @@ interface DataUpdateProps {
 }
 
 export const DataUpdate = observer((props: DataUpdateProps): React.JSX.Element => {
-  const { connection, dvSvc, vm, utils, onLog } = props;
+  const { dvSvc, vm, utils, onLog } = props;
   const [selectedValue, setSelectedValue] = React.useState<TabValue>("update");
   const [updateDialogOpen, setUpdateDialogOpen] = React.useState<boolean>(false);
   const [touchDialogOpen, setTouchDialogOpen] = React.useState<boolean>(false);
@@ -86,11 +85,10 @@ export const DataUpdate = observer((props: DataUpdateProps): React.JSX.Element =
           </div>
         )}
       </TabList>
-      {selectedValue === "update" && <UpdateList connection={connection} dvSvc={dvSvc} vm={vm} onLog={onLog} />}
+      {selectedValue === "update" && <UpdateList dvSvc={dvSvc} vm={vm} onLog={onLog} />}
       {vm.updateFieldAddOpen && <UpdateAddField vm={vm} utils={utils} />}
       {updateDialogOpen && (
         <UpdateDialog
-          connection={connection}
           dvSvc={dvSvc}
           vm={vm}
           utils={utils}
@@ -101,7 +99,6 @@ export const DataUpdate = observer((props: DataUpdateProps): React.JSX.Element =
       )}
       {touchDialogOpen && (
         <TouchDialog
-          connection={connection}
           dvSvc={dvSvc}
           vm={vm}
           utils={utils}

--- a/src/components/UpdateDialog.tsx
+++ b/src/components/UpdateDialog.tsx
@@ -15,7 +15,6 @@ import {
 import { utilService } from "../utils/utils";
 
 interface UpdateDialogProps {
-  connection: ToolBoxAPI.DataverseConnection | null;
   dvSvc: dvService;
   vm: ViewModel;
   utils: utilService;

--- a/src/components/UpdateList.tsx
+++ b/src/components/UpdateList.tsx
@@ -35,7 +35,6 @@ const agTheme = themeQuartz.withParams({
 });
 
 interface UpdateListProps {
-  connection: ToolBoxAPI.DataverseConnection | null;
   dvSvc: dvService;
   vm: ViewModel;
   onLog: (message: string, type?: "info" | "success" | "warning" | "error") => void;
@@ -51,7 +50,7 @@ const defaultColDef: ColDef = {
 };
 
 export const UpdateList = observer((props: UpdateListProps): React.JSX.Element => {
-  const { connection, dvSvc, vm, onLog } = props;
+  const { dvSvc, vm, onLog } = props;
 
   const cols: ColDef<UpdateColumn>[] = [
     { field: "column.displayName", headerName: "Field Name", flex: 2 },
@@ -59,9 +58,7 @@ export const UpdateList = observer((props: UpdateListProps): React.JSX.Element =
       field: "newValue",
       headerName: "New Value",
       cellRenderer: (params: CustomCellRendererProps<UpdateColumn>) =>
-        params.data ? (
-          <UpdateValue updateColumn={params.data} connection={connection} dvSvc={dvSvc} vm={vm} onLog={onLog} />
-        ) : null,
+        params.data ? <UpdateValue updateColumn={params.data} dvSvc={dvSvc} vm={vm} onLog={onLog} /> : null,
     },
     {
       field: "setStatus",

--- a/src/components/UpdateValue.tsx
+++ b/src/components/UpdateValue.tsx
@@ -9,7 +9,6 @@ import { SearchFilled } from "@fluentui/react-icons";
 import { LookupDialog } from "./LookupDialog";
 
 interface UpdateValueProps {
-  connection: ToolBoxAPI.DataverseConnection | null;
   dvSvc: dvService;
   vm: ViewModel;
   updateColumn: UpdateColumn;
@@ -17,7 +16,7 @@ interface UpdateValueProps {
 }
 
 export const UpdateValue = observer((props: UpdateValueProps): React.JSX.Element => {
-  const { connection, updateColumn, dvSvc, vm, onLog } = props;
+  const { updateColumn, dvSvc, vm, onLog } = props;
   const [selectValues, setPicklistValues] = React.useState<SelectionValue[]>([]);
 
   const [lookupPopupOpen, setLookupPopupOpen] = React.useState<boolean>(false);


### PR DESCRIPTION
This pull request refactors several components to remove the unnecessary `connection` prop from the data update workflow. The main goal is to simplify prop passing and reduce coupling between components. The changes affect the `DataUpdate`, `UpdateList`, `UpdateDialog`, and `UpdateValue` components, as well as their usage in parent components.

**Prop Cleanup and Refactoring:**

* Removed the `connection` prop from the `DataUpdate`, `UpdateList`, `UpdateDialog`, and `UpdateValue` components, as well as from their prop interfaces and all usages. This reduces unnecessary prop drilling and simplifies the component interfaces. [[1]](diffhunk://#diff-841da86df3cb7f10da03d6b29755490e1e91e72b017a0e08b727a48a76388a36L14-R21) [[2]](diffhunk://#diff-841da86df3cb7f10da03d6b29755490e1e91e72b017a0e08b727a48a76388a36L89-L93) [[3]](diffhunk://#diff-841da86df3cb7f10da03d6b29755490e1e91e72b017a0e08b727a48a76388a36L104) [[4]](diffhunk://#diff-7621e2522ea6d5fc93d36f13074458adf7092aa8c18a17108c15f0c7e808879aL18) [[5]](diffhunk://#diff-9b95b0165f3c11201222f3610e746cb4302362092da53efe641fc8350a2d4fa6L38) [[6]](diffhunk://#diff-9b95b0165f3c11201222f3610e746cb4302362092da53efe641fc8350a2d4fa6L54-R61) [[7]](diffhunk://#diff-33330eda0a6808b6dc282b3094cf9a2372d9114c43ae92e3de6a4431378e2c78L12-R19) [[8]](diffhunk://#diff-ca169ac27a8252359ceac60a3f72b0041c5d166257d0124863c221c6980225eeL64-R64)

**Minor Code Cleanup:**

* Removed an unused import of `dvService` in `DataGrid.tsx`, and made a minor formatting adjustment to the `AgGridReact` usage. [[1]](diffhunk://#diff-2e8f0f0f90909ffbfe5562065a1ecb014b31e6ff3057eae26bbacb068f14a214L30) [[2]](diffhunk://#diff-2e8f0f0f90909ffbfe5562065a1ecb014b31e6ff3057eae26bbacb068f14a214L92-R92)