### PR TITLE
fix: use onLog for picklist metadata logging and return integer array for MultiSelectPicklist

### DIFF
--- a/CALCULATED_COLUMNS.md
+++ b/CALCULATED_COLUMNS.md
@@ -1,224 +1,170 @@
-# Calculated Columns for BulkDataStudio
+# Calculated Fields Reference
 
-## Overview
+This document lists all currently supported calculated-field options in Bulk Data Studio.
 
-Calculated columns allow you to dynamically compute update values based on record data, system values, and expressions. This feature is inspired by XRM Tokens and Bulk Data Updater, providing flexible value calculation for bulk operations.
+## How To Use
 
-## Setting Up Calculated Columns
+1. Add a field in the Update list.
+2. Set Action to `Calculated`.
+3. Enter an expression template.
+4. Use preview/validation in the editor before running a bulk update.
 
-1. **Enable Calculated Mode**: In the Update Value editor, select "Calculated" from the `setStatus` dropdown
-2. **Define Expression**: Enter your expression template in the Expression Template field
-3. **Preview**: View the calculated result in real-time as you type
-4. **Validate**: The system shows errors if the expression is invalid
+## Expression Processing Order
 
-## Token Types
+Expressions are processed in this order:
 
-### Column Tokens
+1. Column tokens: `{field}` / `{field|raw}`
+2. Conditionals: `<iif|...>`
+3. System tokens: `<system|...>`
+4. Math functions: `<math|...>`
+5. Formatting functions: `<Upper>`, `<Lower>`, `<Trim|...>`, `<Left|...>`, `<Right|...>`, `<SubStr|...>`
+6. Replacement function: `<Replace|old|new>`
 
-Reference field values from the current record:
+## All Available Options
 
-```
-{fieldname}              → Get field value with label (for lookups)
-{fieldname|raw}          → Get raw field value
-{parent.childfield}      → Navigate related records (dot notation)
-```
+### 1. Column Tokens
 
-**Examples:**
+- `{fieldname}`: Returns the field value.
+- `{fieldname|raw}`: Returns raw value mode (same token format, useful for parity with XRM token style).
+- `{parent.child}`: Dot notation is supported by the evaluator for nested object paths.
 
-- `{firstname}` → Returns the first name
-- `{account.name}` → Returns the parent account's name
-- `{status|raw}` → Returns numeric value for status field
+Examples:
 
-### System Tokens
-
-Access system-level information:
-
-```
-<system|now|>            → Current date/time (ISO 8601)
-<system|today|>          → Current date only
-<system|year|>           → Current year (e.g., 2026)
-<system|month|>          → Current month (01-12)
-<system|day|>            → Current day of month
-<system|hour|>           → Current hour (00-23)
-<system|minute|>         → Current minute (00-59)
-<system|timestamp|>      → Current timestamp in milliseconds
+```text
+{firstname}
+{statuscode|raw}
+{account.name}
 ```
 
-**Examples:**
+### 2. Conditional Token
 
-- `Updated on <system|today|>` → "Updated on 2026-02-19"
-- `<system|year|>-<system|month|>-<system|day|>` → "2026-02-19"
+Format:
 
-### Conditional Logic
-
-Use IIF (If-If-Else) for decision-based values:
-
-```
+```text
 <iif|value|operator|compare|then|else>
 ```
 
-**Operators:**
+Supported operators:
 
-- Comparison: `eq`, `ne`, `gt`, `gte`, `lt`, `lte`
-- String: `contains`, `startswith`, `endswith`
+- `eq` or `=`
+- `ne`, `!=`, or `<>`
+- `gt` or `>`
+- `gte` or `>=`
+- `lt` or `<`
+- `lte` or `<=`
+- `contains`
+- `startswith`
+- `endswith`
 
-**Examples:**
+Examples:
 
-- `<iif|{status}|eq|Active|Yes|No>` → "Yes" if status equals "Active"
-- `<iif|{rating}|gt|100|High|Low>` → "High" if rating > 100
-- `<iif|{email}|contains|@acme.com|Internal|External>` → "Internal" for acme.com emails
-
-### Formatting Functions
-
-Transform text values:
-
-```
-<Upper>                  → Convert to UPPERCASE
-<Lower>                  → Convert to lowercase
-<Trim|chars>             → Remove leading/trailing characters
-<TrimStart|chars>        → Remove leading characters only
-<TrimEnd|chars>          → Remove trailing characters only
-<SubStr|start|length>    → Extract substring
-<Left|length>            → Get left N characters
-<Right|length>           → Get right N characters
-<Replace|old|new>        → Replace text
-<Pad|R|length|char>      → Pad with character
+```text
+<iif|statuscode|eq|1|Active|Inactive>
+<iif|emailaddress1|contains|@contoso.com|Internal|External>
 ```
 
-**Examples:**
+### 3. System Tokens
 
-- `{firstname}<Upper>` → "JOHN"
-- `<SubStr|0|3>{lastname}` → First 3 chars of last name
-- `<Replace|Old Company|New Company>{description}` → Replace company name
+Format:
 
-### Math Operations
-
-Perform calculations on numeric values:
-
+```text
+<system|value|>
 ```
+
+Supported values:
+
+- `now`: current date/time (ISO)
+- `today`: current date (YYYY-MM-DD)
+- `year`
+- `month` (01-12)
+- `day` (01-31)
+- `hour` (00-23)
+- `minute` (00-59)
+- `timestamp` (Unix ms)
+
+Examples:
+
+```text
+Updated <system|today|>
+<system|year|>-<system|month|>-<system|day|>
+```
+
+### 4. Math Function
+
+Format:
+
+```text
 <math|operator|value>
 ```
 
-**Operators:** `+`, `-`, `*`, `/`
+Supported operators:
 
-**Examples:**
+- `+`
+- `-`
+- `*`
+- `/`
 
-- `{quantity}<math|*|1.10>` → Increase quantity by 10%
-- `{price}<math|-|0.05>` → Subtract 0.05 from price
+Examples:
 
-## Complex Examples
-
-### 1. Append Current Date
-
-**Field:** Description  
-**Expression:**
-
+```text
+{revenue}<math|*|1.1>
+{score}<math|+|5>
 ```
+
+### 5. Formatting Functions
+
+Supported formatting tags:
+
+- `<Upper>`: uppercase preceding segment
+- `<Lower>`: lowercase preceding segment
+- `<Trim|chars>`: remove characters listed in `chars` from preceding segment
+- `<Trim>`: trim whitespace from preceding segment
+- `<Left|length>`: first N chars of preceding segment
+- `<Right|length>`: last N chars of preceding segment
+- `<SubStr|start|length>`: substring from preceding segment
+
+Examples:
+
+```text
+{fullname}<Upper>
+{telephone1}<Right|4>
+{name}<Trim|*>
+```
+
+### 6. Replace Function
+
+Format:
+
+```text
+<Replace|old|new>
+```
+
+Example:
+
+```text
+{description}<Replace|old company|new company>
+```
+
+## Practical Examples
+
+```text
 {description} - Updated <system|today|>
+<iif|statuscode|eq|1|Ready for follow-up|Pending review>
+{name}<Upper><Left|8>
+{creditlimit}<math|*|1.05>
 ```
 
-**Result:** "Original description - Updated 2026-02-19"
+## Notes And Limitations
 
----
+- If a field is missing or null, token replacement returns an empty string.
+- For calculated updates, referenced top-level fields are auto-fetched before evaluation.
+- Navigation paths in templates (for example `parent.child`) are not auto-fetched by the prefetch step and may require the data to already exist in the record context.
+- Math operates on the trailing numeric portion before the `<math|...>` tag.
+- Unknown system tokens resolve to empty output.
 
-### 2. Concatenate with Conditional
+## Quick Checklist
 
-**Field:** Notes  
-**Expression:**
-
-```
-<iif|{status}|eq|Completed|Task finished on <system|today|>|Task is pending>
-```
-
-**Result (if completed):** "Task finished on 2026-02-19"  
-**Result (if pending):** "Task is pending"
-
----
-
-### 3. Dynamic Account Code
-
-**Field:** AccountCode  
-**Expression:**
-
-```
-<Left|2>{account.name}<Upper><system|year|>
-```
-
-**Result:** "ACACME2026" (first 2 chars of account name in uppercase + year)
-
----
-
-### 4. Format Phone Number
-
-**Field:** FormattedPhone  
-**Expression:**
-
-```
-(<Left|3>{phone>) <SubStr|3|3>-<Right|4>{phone}>
-```
-
-**Result:** "(555) 123-4567" (from "5551234567")
-
----
-
-### 5. Status-Based Pricing
-
-**Field:** FinalPrice  
-**Expression:**
-
-```
-<iif|{tier}|eq|Premium|{price}<math|*|0.90>|{price}>
-```
-
-**Result:** 10% discount applied if tier is "Premium"
-
----
-
-## Best Practices
-
-### ✅ Do's
-
-- **Test with sample data** - Use the preview to verify expressions work
-- **Use meaningful delimiters** - Make concatenated values readable
-- **Combine operators logically** - Nest conditionals for complex scenarios
-- **Handle missing values** - Expressions gracefully ignore null/undefined fields
-- **Document complex templates** - Add notes about formula logic
-
-### ❌ Don'ts
-
-- **Reference non-existent fields** - They'll be treated as empty strings
-- **Create circular logic** - Don't reference fields you're updating
-- **Assume data format** - Verify field types before calculations
-- **Overcomplicate expressions** - Keep templates readable and maintainable
-
-## Integration with Bulk Operations
-
-When executing bulk updates with calculated columns:
-
-1. **Records are fetched** - Required fields are retrieved for each record
-2. **Expressions evaluated** - Each record's data is substituted into the template
-3. **Values calculated** - Formulas are executed per-record
-4. **Updates applied** - Calculated values are written to the target field
-5. **Results logged** - Success/error details are recorded
-
-## Limitations & Notes
-
-- **Lookup navigation** - Only one level of related data (dot notation) is supported
-- **Number precision** - Math operations maintain JavaScript Number precision
-- **Field availability** - Only fields included in the fetch are available for calculation
-- **Performance** - Batch size is optimized; very large datasets may take time
-- **Date formats** - System tokens return ISO 8601 format by default
-
-## Error Handling
-
-The editor shows real-time validation:
-
-- ❌ **Red border/Error message** - Expression has syntax errors
-- ✅ **Green check + preview** - Expression is valid
-- ⚠️ **Yellow warning** - Field referenced but might be missing
-
-## See Also
-
-- Expression Evaluator API: `ExpressionEvaluator` class
-- Update Column Data Model: `UpdateColumn` entity
-- Expression patterns based on: XRM Tokens, Bulk Data Updater
+- Keep expressions simple and test with preview first.
+- Use explicit delimiters when concatenating values.
+- Validate condition operators and numeric math inputs.
+- Prefer top-level field references for reliable bulk execution.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ Bulk Data Studio, a respectful clone of Jonas Rapp's [Bulk Data Updater](https:/
 - ✅ Allow Edit of FetchXml
 - ✅ Touch per field
 - ✅ Some XrmTokens for calculated fields
+- 📘 Calculated fields reference: [All calculated field options](CALCULATED_COLUMNS.md)
+- ✅ Clone record with child tables
+
+22/06/26
+- Added clone record with child tables functionality
+- Added option to be called from other tools that provide fetchxml
+- Added support for multi choice lists.
 
 30/03/26
 - Fixed [#33 Does not load active stage](https://github.com/LinkeD365/BulkDataStudio/issues/33)

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -22,7 +22,7 @@
         "react-simple-code-editor": "^0.14.1"
       },
       "devDependencies": {
-        "@pptb/types": "^1.2.1",
+        "@pptb/types": "^1.2.3",
         "@types/prismjs": "^1.26.5",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
@@ -35,13 +35,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.28.6.tgz",
-      "integrity": "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -50,9 +50,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.6.tgz",
-      "integrity": "sha512-2lfu57JtzctfIrcGMz992hyLlByuzgIk58+hhGCxjKZ3rWI82NnVLjXcaTqkI2NvlcvOskZaiZ5kjUALo3Lpxg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -60,22 +60,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.6.tgz",
-      "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/generator": "^7.28.6",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -92,14 +91,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.6.tgz",
-      "integrity": "sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -109,14 +108,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -126,9 +125,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -136,29 +135,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -178,9 +177,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -188,9 +187,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -198,9 +197,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -208,27 +207,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.6.tgz",
-      "integrity": "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.6"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -279,33 +278,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.6.tgz",
-      "integrity": "sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/generator": "^7.28.6",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.6",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -313,14 +312,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.6.tgz",
-      "integrity": "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -806,7 +805,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
       "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.3",
         "@floating-ui/utils": "^0.2.10"
@@ -2447,9 +2445,9 @@
       }
     },
     "node_modules/@pptb/types": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@pptb/types/-/types-1.2.1.tgz",
-      "integrity": "sha512-U8/Tij6CB09T+g/lE3gubdNnw7wmHz4LKoaWCMiXsv6BTNliXD99Wt6XW1K7WWdUwhIknKK9Jor3YhzoboVhHA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@pptb/types/-/types-1.2.3.tgz",
+      "integrity": "sha512-6IvbIASYlqpyT6BPa/hVDMlE45u16aDKCrtPZO/WYrJSnOp5icfNHfYwPxJ6iUwmjKB7LNNTX/g3DGJxf+TVdw==",
       "dev": true,
       "license": "GPL-3.0",
       "bin": {
@@ -2891,7 +2889,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2902,7 +2899,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -2976,19 +2972,22 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.15",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.15.tgz",
-      "integrity": "sha512-kX8h7K2srmDyYnXRIppo4AH/wYgzWVCs+eKr3RusRSQ5PvRYoEFmR/I0PbdTjKFAoKqp5+kbxnNTFO9jOfSVJg==",
+      "version": "2.10.38",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
+      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
       "dev": true,
       "funding": [
         {
@@ -3005,13 +3004,12 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -3021,9 +3019,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001764",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001764.tgz",
-      "integrity": "sha512-9JGuzl2M+vPL+pz70gtMF9sHdMFbY9FJaQBi186cHKH3pSzDvzoUJUPV6fqiKIMyXbud9ZLg4F3Yza1vJ1+93g==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "dev": true,
       "funding": [
         {
@@ -3079,9 +3077,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.267",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
-      "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
+      "version": "1.5.376",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.376.tgz",
+      "integrity": "sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==",
       "dev": true,
       "license": "ISC"
     },
@@ -3089,8 +3087,7 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-autoplay": {
       "version": "8.6.0",
@@ -3294,7 +3291,6 @@
       "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.15.0.tgz",
       "integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -3377,11 +3373,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "version": "2.0.48",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
+      "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -3405,7 +3404,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3473,7 +3471,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3486,7 +3483,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3737,12 +3733,11 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
-      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "react-simple-code-editor": "^0.14.1"
   },
   "devDependencies": {
-    "@pptb/types": "^1.2.3.beta.0",
+    "@pptb/types": "^1.2.3",
     "@types/prismjs": "^1.26.5",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "dev": "vite",
     "preview": "vite preview",
     "watch": "vite build --watch",
-    "finalize-package": "npm shrinkwrap"
+    "finalize-package": "npm shrinkwrap",
+    "validate": "npx pptb-validate"
   },
   "dependencies": {
     "@fluentui/react-components": "^9.72.9",
@@ -53,7 +54,7 @@
     "react-simple-code-editor": "^0.14.1"
   },
   "devDependencies": {
-    "@pptb/types": "^1.2.1",
+    "@pptb/types": "^1.2.3.beta.0",
     "@types/prismjs": "^1.26.5",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",

--- a/pptb.config.json
+++ b/pptb.config.json
@@ -1,0 +1,11 @@
+{
+  "invocation": {
+    "version": "1.0.0",
+    "capabilities": ["fetchxml"],
+    "prefill": {
+      "properties": {
+        "fetchXml": { "type": "string" }
+      }
+    }
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,14 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { useConnection, useEventLog, useToolboxEvents } from "./hooks/useToolboxAPI";
-import { FluentProvider, webDarkTheme, webLightTheme } from "@fluentui/react-components";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useConnection,
+  useEventLog,
+  useToolboxEvents,
+} from "./hooks/useToolboxAPI";
+import {
+  FluentProvider,
+  webDarkTheme,
+  webLightTheme,
+} from "@fluentui/react-components";
 import { BulkDataStudio } from "./components/BulkDataStudio";
 import { dvService } from "./utils/dataverseService";
 import { utilService } from "./utils/utils";
@@ -10,6 +18,7 @@ function App() {
   const { connection, refreshConnection } = useConnection();
   const { addLog } = useEventLog();
   const [theme, setTheme] = useState<string>("light");
+  const invocationContextHandledRef = useRef(false);
   // Handle platform events
   const handleEvent = useCallback(
     async (event: string, _data: any) => {
@@ -76,9 +85,117 @@ function App() {
     });
   }, [dvSvc, viewModel, addLog]);
 
+  useEffect(() => {
+    if (!connection || !dvSvc || !utils) {
+      return;
+    }
+
+    if (invocationContextHandledRef.current) {
+      return;
+    }
+
+    invocationContextHandledRef.current = true;
+
+    (async () => {
+      try {
+        if (!window.toolboxAPI.invocation) {
+          return;
+        }
+
+        const launchContext =
+          await window.toolboxAPI.invocation.getLaunchContext();
+        if (!launchContext || typeof launchContext !== "object") {
+          return;
+        }
+
+        const fetchXmlCandidate =
+          (typeof launchContext.fetchXml === "string" &&
+            launchContext.fetchXml) ||
+          (typeof launchContext.fetchxml === "string" &&
+            launchContext.fetchxml) ||
+          (typeof launchContext.xml === "string" && launchContext.xml) ||
+          "";
+        const fetchXml = fetchXmlCandidate.trim();
+
+        if (!fetchXml) {
+          addLog(
+            "Invocation context was provided but no fetchXml payload was found",
+            "warning",
+          );
+          return;
+        }
+
+        addLog(
+          "Invocation payload received. Running FetchXML query...",
+          "info",
+        );
+        viewModel.selectedView = undefined;
+        viewModel.fetchXml = fetchXml;
+        //viewModel.fetchFields = [];
+
+        const tableMatch = fetchXml.match(
+          /<entity\s+name=['\"]([^'\"]+)['\"]/i,
+        );
+        const tableLogicalName = tableMatch?.[1];
+
+        if (tableLogicalName) {
+          if (!viewModel.tables || viewModel.tables.length === 0) {
+            viewModel.tables = await dvSvc.getTables();
+          }
+
+          const matchedTable = viewModel.tables.find(
+            (t) => t.logicalName === tableLogicalName,
+          );
+          if (matchedTable) {
+            viewModel.selectedTable = matchedTable;
+            if (!matchedTable.fields || matchedTable.fields.length === 0) {
+              matchedTable.fields = await dvSvc.getFields(
+                matchedTable.logicalName,
+              );
+            }
+          } else {
+            addLog(
+              `Table ${tableLogicalName} from FetchXML was not found in this environment`,
+              "warning",
+            );
+          }
+        }
+
+      //  viewModel.isDataLoading = true;
+        // try {
+        //   await utils.loadData();
+        //   await window.toolboxAPI.invocation.returnData({
+        //     status: "success",
+        //     recordCount: Array.isArray(viewModel.data)
+        //       ? viewModel.data.length
+        //       : 0,
+        //   });
+        //   addLog("FetchXML invocation query completed", "success");
+        // } finally {
+        //   viewModel.isDataLoading = false;
+        // }
+      } catch (error: any) {
+        const message =
+          error && typeof error.message === "string"
+            ? error.message
+            : String(error);
+        addLog(`Failed to run invocation FetchXML query: ${message}`, "error");
+        await window.toolboxAPI.invocation.returnData({
+          status: "error",
+          error: message,
+        });
+      }
+    })();
+  }, [connection, dvSvc, utils, viewModel, addLog]);
   return (
     <FluentProvider theme={theme === "dark" ? webDarkTheme : webLightTheme}>
-      <BulkDataStudio connection={connection} dvSvc={dvSvc!} vm={viewModel} onLog={addLog} utils={utils!} />
+      <BulkDataStudio
+        connection={connection}
+        dvSvc={dvSvc!}
+        vm={viewModel}
+        onLog={addLog}
+        utils={utils!}
+      />
     </FluentProvider>
   );
 }

--- a/src/components/BulkDataStudio.tsx
+++ b/src/components/BulkDataStudio.tsx
@@ -236,7 +236,12 @@ export const BulkDataStudio = observer((props: BulkDataStudioProps): React.JSX.E
                 onLog(`Error loading lookup metadata for field ${column.logicalName}: ${error}`, "warning");
               }
             } else if (
-              (column.type === "Picklist" || column.type === "State" || column.type === "Status") &&
+              (
+                column.type === "Picklist" ||
+                column.type === "MultiSelectPicklist" ||
+                column.type === "State" ||
+                column.type === "Status"
+              ) &&
               (!column.choiceValues || column.choiceValues.length === 0)
             ) {
               try {

--- a/src/components/BulkDataStudio.tsx
+++ b/src/components/BulkDataStudio.tsx
@@ -254,6 +254,7 @@ export const BulkDataStudio = observer((props: BulkDataStudioProps): React.JSX.E
         }
 
         vm.updateCols = updateCols;
+
         onLog(`Configuration loaded successfully with ${updateCols.length} fields`, "success");
         window.toolboxAPI.utils.showNotification({
           title: "Configuration Loaded",

--- a/src/components/ClonePanel.tsx
+++ b/src/components/ClonePanel.tsx
@@ -26,7 +26,7 @@ import {
   TabList,
   Text,
 } from "@fluentui/react-components";
-import { Add24Regular, Delete24Regular } from "@fluentui/react-icons";
+import { Add24Regular, Delete24Regular, FolderOpen24Regular, Save24Regular } from "@fluentui/react-icons";
 import { CloneChildConfig, Column, Table, ViewModel } from "../model/vm";
 import { ChildTableRelationship, dvService } from "../utils/dataverseService";
 import { utilService } from "../utils/utils";
@@ -40,16 +40,136 @@ interface ClonePanelProps {
 
 export const ClonePanel = observer((props: ClonePanelProps): React.JSX.Element => {
   const { vm, dvSvc, utils, onLog } = props;
+
+  interface CloneChildConfigDto {
+    childTableLogicalName: string;
+    parentLookupFieldLogicalName: string;
+    parentLookupFieldSchemaName: string;
+    excludedFields: string[];
+    childConfigs: CloneChildConfigDto[];
+  }
+
+  const serializeCloneChildConfig = (config: CloneChildConfig): CloneChildConfigDto => ({
+    childTableLogicalName: config.childTableLogicalName,
+    parentLookupFieldLogicalName: config.parentLookupFieldLogicalName,
+    parentLookupFieldSchemaName: config.parentLookupFieldSchemaName,
+    excludedFields: [...config.excludedFields],
+    childConfigs: config.childConfigs.map(serializeCloneChildConfig),
+  });
+
+  const deserializeCloneChildConfig = (raw: any): CloneChildConfig | undefined => {
+    if (!raw || typeof raw !== "object") {
+      return undefined;
+    }
+
+    const config = new CloneChildConfig();
+    if (typeof raw.childTableLogicalName === "string") {
+      config.setChildTable(raw.childTableLogicalName);
+    }
+    if (typeof raw.parentLookupFieldLogicalName === "string") {
+      config.setLookupField(
+        raw.parentLookupFieldLogicalName,
+        typeof raw.parentLookupFieldSchemaName === "string"
+          ? raw.parentLookupFieldSchemaName
+          : raw.parentLookupFieldLogicalName,
+      );
+    }
+    if (Array.isArray(raw.excludedFields)) {
+      config.setExcludedFields(raw.excludedFields.filter((f: unknown) => typeof f === "string"));
+    }
+
+    if (Array.isArray(raw.childConfigs)) {
+      const childConfigs = raw.childConfigs
+        .map((child: any) => deserializeCloneChildConfig(child))
+        .filter((child: CloneChildConfig | undefined): child is CloneChildConfig => !!child);
+      config.setChildConfigs(childConfigs);
+    }
+
+    return config;
+  };
+
   const [loadingPanelData, setLoadingPanelData] = React.useState(false);
   const [cloning, setCloning] = React.useState(false);
   const [lookupFieldOptions, setLookupFieldOptions] = React.useState<Record<string, Column[]>>({});
   const [activeTab, setActiveTab] = React.useState<"exclude" | "children">("exclude");
   const [parentFieldQuery, setParentFieldQuery] = React.useState("");
-  const [childTables, setChildTables] = React.useState<Table[]>([]);
-  const [childRelationshipsByTable, setChildRelationshipsByTable] = React.useState<Record<string, string[]>>({});
+  const [childTablesByParent, setChildTablesByParent] = React.useState<Record<string, Table[]>>({});
+  const [childRelationshipsByParent, setChildRelationshipsByParent] = React.useState<
+    Record<string, Record<string, string[]>>
+  >({});
   const [parentFieldsCache, setParentFieldsCache] = React.useState<Record<string, Column[]>>({});
   const [keyFieldsByTable, setKeyFieldsByTable] = React.useState<Record<string, string[]>>({});
   const [confirmOpen, setConfirmOpen] = React.useState(false);
+  const childTablesByParentRef = React.useRef<Record<string, Table[]>>({});
+  const childRelationshipsByParentRef = React.useRef<Record<string, Record<string, string[]>>>({});
+
+  React.useEffect(() => {
+    childTablesByParentRef.current = childTablesByParent;
+  }, [childTablesByParent]);
+
+  React.useEffect(() => {
+    childRelationshipsByParentRef.current = childRelationshipsByParent;
+  }, [childRelationshipsByParent]);
+
+  const collectAllConfigs = React.useCallback((configs: CloneChildConfig[]): CloneChildConfig[] => {
+    const flattened: CloneChildConfig[] = [];
+    for (const config of configs) {
+      flattened.push(config);
+      if (config.childConfigs.length > 0) {
+        flattened.push(...collectAllConfigs(config.childConfigs));
+      }
+    }
+    return flattened;
+  }, []);
+
+  const ensureTableMetadata = React.useCallback(
+    async (table: Table): Promise<void> => {
+      if (!table.fields || table.fields.length === 0) {
+        table.fields = await dvSvc.getFields(table.logicalName);
+      }
+      const keyFields = await dvSvc.getAlternateKeyFieldNames(table.logicalName);
+      setKeyFieldsByTable((prev) => ({ ...prev, [table.logicalName]: Array.from(keyFields) }));
+    },
+    [dvSvc],
+  );
+
+  const ensureChildMetadataForParent = React.useCallback(
+    async (parentTableLogicalName: string): Promise<void> => {
+      if (!parentTableLogicalName) {
+        return;
+      }
+
+      const alreadyLoaded =
+        !!childRelationshipsByParentRef.current[parentTableLogicalName] &&
+        !!childTablesByParentRef.current[parentTableLogicalName];
+      if (alreadyLoaded) {
+        return;
+      }
+
+      const childRelationships = await dvSvc.getChildTableRelationships(parentTableLogicalName);
+      const relationshipMap = childRelationships.reduce(
+        (acc, relationship: ChildTableRelationship) => {
+          if (!acc[relationship.referencingEntity]) {
+            acc[relationship.referencingEntity] = [];
+          }
+          if (!acc[relationship.referencingEntity].includes(relationship.referencingAttribute)) {
+            acc[relationship.referencingEntity].push(relationship.referencingAttribute);
+          }
+          return acc;
+        },
+        {} as Record<string, string[]>,
+      );
+      const childLogicalNames = Object.keys(relationshipMap);
+      const resolvedChildTables = vm.tables.filter((t) => childLogicalNames.includes(t.logicalName));
+
+      setChildRelationshipsByParent((prev) => ({ ...prev, [parentTableLogicalName]: relationshipMap }));
+      setChildTablesByParent((prev) => ({ ...prev, [parentTableLogicalName]: resolvedChildTables }));
+
+      // Warm child table metadata in the background so field filters are responsive.
+      void Promise.allSettled(resolvedChildTables.map((table) => ensureTableMetadata(table)));
+    },
+    [dvSvc, ensureTableMetadata, vm.tables],
+  );
 
   React.useEffect(() => {
     if (!vm.clonePanelOpen || !vm.selectedTable) return;
@@ -57,7 +177,17 @@ export const ClonePanel = observer((props: ClonePanelProps): React.JSX.Element =
     let isDisposed = false;
 
     (async () => {
-      setLoadingPanelData(true);
+      const needsPanelLoad =
+        vm.tables.length === 0 ||
+        !selectedTable.fields ||
+        selectedTable.fields.length === 0 ||
+        !keyFieldsByTable[selectedTable.logicalName] ||
+        !childRelationshipsByParentRef.current[selectedTable.logicalName] ||
+        !childTablesByParentRef.current[selectedTable.logicalName];
+
+      if (needsPanelLoad) {
+        setLoadingPanelData(true);
+      }
       try {
         if (vm.tables.length === 0) {
           vm.tables = await dvSvc.getTables();
@@ -76,41 +206,22 @@ export const ClonePanel = observer((props: ClonePanelProps): React.JSX.Element =
           (f) => availableParentFieldNames.has(f) && !parentKeyFields.has(f),
         );
 
-        const childRelationships = await dvSvc.getChildTableRelationships(selectedTable.logicalName);
-        const relationshipMap = childRelationships.reduce(
-          (acc, relationship: ChildTableRelationship) => {
-            if (!acc[relationship.referencingEntity]) {
-              acc[relationship.referencingEntity] = [];
-            }
-            if (!acc[relationship.referencingEntity].includes(relationship.referencingAttribute)) {
-              acc[relationship.referencingEntity].push(relationship.referencingAttribute);
-            }
-            return acc;
-          },
-          {} as Record<string, string[]>,
-        );
-        if (!isDisposed) {
-          setChildRelationshipsByTable(relationshipMap);
-        }
-        const childLogicalNames = Object.keys(relationshipMap);
+        await ensureChildMetadataForParent(selectedTable.logicalName);
 
-        const resolvedChildTables = vm.tables.filter((t) => childLogicalNames.includes(t.logicalName));
-        if (!isDisposed) {
-          setChildTables(resolvedChildTables);
-        }
+        const existingConfigs = collectAllConfigs(vm.cloneChildConfigs).filter((cfg) => cfg.childTableLogicalName);
+        const preloadDescendants = async () => {
+          await Promise.all(
+            existingConfigs.map(async (cfg) => {
+              await ensureChildMetadataForParent(cfg.childTableLogicalName);
+            }),
+          );
+        };
 
-        // Warm child table metadata in the background so dropdowns/field lists are ready when selected.
-        void Promise.allSettled(
-          resolvedChildTables.map(async (table) => {
-            if (!table.fields || table.fields.length === 0) {
-              table.fields = await dvSvc.getFields(table.logicalName);
-            }
-            const childKeyFields = await dvSvc.getAlternateKeyFieldNames(table.logicalName);
-            if (!isDisposed) {
-              setKeyFieldsByTable((prev) => ({ ...prev, [table.logicalName]: Array.from(childKeyFields) }));
-            }
-          }),
-        );
+        if (needsPanelLoad) {
+          await preloadDescendants();
+        } else {
+          void preloadDescendants();
+        }
       } catch (error: any) {
         const message = error && typeof error.message === "string" ? error.message : String(error);
         onLog(`Error preparing clone panel: ${message}`, "error");
@@ -124,7 +235,13 @@ export const ClonePanel = observer((props: ClonePanelProps): React.JSX.Element =
     return () => {
       isDisposed = true;
     };
-  }, [vm.clonePanelOpen, vm.selectedTable]);
+  }, [
+    collectAllConfigs,
+    ensureChildMetadataForParent,
+    vm.clonePanelOpen,
+    vm.selectedTable,
+    vm.selectedTable?.logicalName,
+  ]);
 
   const parentFields = React.useMemo(() => {
     if (!vm.selectedTable) return [];
@@ -148,28 +265,30 @@ export const ClonePanel = observer((props: ClonePanelProps): React.JSX.Element =
     });
   }, [parentFields, parentFieldQuery]);
 
-  const loadLookupFieldOptions = async (config: CloneChildConfig): Promise<void> => {
-    if (!config.childTableLogicalName || !vm.selectedTable) {
+  const loadLookupFieldOptions = async (
+    config: CloneChildConfig,
+    parentTableLogicalName: string,
+  ): Promise<void> => {
+    if (!config.childTableLogicalName || !parentTableLogicalName) {
       setLookupFieldOptions((prev) => ({ ...prev, [config.id]: [] }));
       return;
     }
 
+    await ensureChildMetadataForParent(parentTableLogicalName);
+
     const childTable =
-      childTables.find((t) => t.logicalName === config.childTableLogicalName) ||
+      (childTablesByParent[parentTableLogicalName] || []).find((t) => t.logicalName === config.childTableLogicalName) ||
       vm.tables.find((t) => t.logicalName === config.childTableLogicalName);
     if (!childTable) {
       setLookupFieldOptions((prev) => ({ ...prev, [config.id]: [] }));
       return;
     }
 
-    if (!childTable.fields || childTable.fields.length === 0) {
-      childTable.fields = await dvSvc.getFields(childTable.logicalName);
-    }
+    await ensureTableMetadata(childTable);
 
-    const childKeyFields = await dvSvc.getAlternateKeyFieldNames(childTable.logicalName);
-    setKeyFieldsByTable((prev) => ({ ...prev, [childTable.logicalName]: Array.from(childKeyFields) }));
-
-    const relationshipLookupNames = new Set(childRelationshipsByTable[childTable.logicalName] || []);
+    const relationshipLookupNames = new Set(
+      childRelationshipsByParent[parentTableLogicalName]?.[childTable.logicalName] || [],
+    );
     let matchingLookups: Column[] = [];
 
     if (relationshipLookupNames.size > 0) {
@@ -187,7 +306,7 @@ export const ClonePanel = observer((props: ClonePanelProps): React.JSX.Element =
             const targetLogicalName = await dvSvc.getLookupTargetTable(childTable.logicalName, field.logicalName);
             field.lookupTargetTable = vm.tables.find((t) => t.logicalName === targetLogicalName);
           }
-          if (field.lookupTargetTable?.logicalName === vm.selectedTable.logicalName) {
+          if (field.lookupTargetTable?.logicalName === parentTableLogicalName) {
             matchingLookups.push(field);
           }
         } catch (error: any) {
@@ -215,16 +334,44 @@ export const ClonePanel = observer((props: ClonePanelProps): React.JSX.Element =
     vm.cloneChildConfigs.push(new CloneChildConfig());
   };
 
-  const removeChildConfig = (config: CloneChildConfig) => {
-    const index = vm.cloneChildConfigs.indexOf(config);
-    if (index === -1) return;
-    vm.cloneChildConfigs.splice(index, 1);
+  const clearLookupOptionsForTree = React.useCallback((config: CloneChildConfig) => {
     setLookupFieldOptions((prev) => {
       const updated = { ...prev };
-      delete updated[config.id];
+      for (const item of collectAllConfigs([config])) {
+        delete updated[item.id];
+      }
       return updated;
     });
+  }, [collectAllConfigs]);
+
+  const removeChildConfig = (config: CloneChildConfig, parentConfig?: CloneChildConfig) => {
+    if (parentConfig) {
+      parentConfig.removeChildConfig(config);
+    } else {
+      vm.cloneChildConfigs = vm.cloneChildConfigs.filter((item) => item !== config);
+    }
+    clearLookupOptionsForTree(config);
   };
+
+  const addNestedChildConfig = async (parentConfig: CloneChildConfig) => {
+    if (!parentConfig.childTableLogicalName) {
+      return;
+    }
+    await ensureChildMetadataForParent(parentConfig.childTableLogicalName);
+    parentConfig.addChildConfig(new CloneChildConfig());
+  };
+
+  const hasInvalidChildConfig = React.useCallback((configs: CloneChildConfig[]): boolean => {
+    for (const config of configs) {
+      if (config.childTableLogicalName && !config.parentLookupFieldLogicalName) {
+        return true;
+      }
+      if (config.childConfigs.length > 0 && hasInvalidChildConfig(config.childConfigs)) {
+        return true;
+      }
+    }
+    return false;
+  }, []);
 
   const toggleParentSkip = (fieldLogicalName: string, checked: boolean) => {
     if (checked) {
@@ -244,6 +391,184 @@ export const ClonePanel = observer((props: ClonePanelProps): React.JSX.Element =
       return;
     }
     config.setExcludedFields(config.excludedFields.filter((f) => f !== fieldLogicalName));
+  };
+
+  const renderChildConfigCard = (
+    config: CloneChildConfig,
+    index: number,
+    parentTableLogicalName: string,
+    depth: number,
+    parentConfig?: CloneChildConfig,
+  ): React.JSX.Element => {
+    const selectedChildTable = vm.tables.find((t) => t.logicalName === config.childTableLogicalName);
+    const childFields = selectedChildTable?.fields || [];
+    const childKeySet = new Set(selectedChildTable ? keyFieldsByTable[selectedChildTable.logicalName] || [] : []);
+    const lookupOptions = lookupFieldOptions[config.id] || [];
+    const selectedLookup = lookupOptions.find((f) => f.logicalName === config.parentLookupFieldLogicalName);
+    const selectedChildTableText = selectedChildTable
+      ? `${selectedChildTable.displayName || selectedChildTable.logicalName} (${selectedChildTable.logicalName})`
+      : config.childTableLogicalName || undefined;
+    const selectedLookupText = selectedLookup
+      ? `${selectedLookup.displayName || selectedLookup.logicalName} (${selectedLookup.logicalName})`
+      : config.parentLookupFieldLogicalName || undefined;
+    const visibleChildFields = childFields.filter(
+      (f) => f.logicalName !== selectedChildTable?.primaryIdAttribute && !childKeySet.has(f.logicalName),
+    );
+    const availableChildTables = childTablesByParent[parentTableLogicalName] || [];
+
+    return (
+      <div
+        key={config.id}
+        style={{
+          border: "1px solid var(--colorNeutralStroke2)",
+          borderRadius: "8px",
+          padding: "10px",
+          display: "flex",
+          flexDirection: "column",
+          gap: "10px",
+          marginLeft: `${depth * 12}px`,
+          background: depth > 0 ? "var(--colorNeutralBackground2)" : "var(--colorNeutralBackground1)",
+        }}
+      >
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <Text weight="semibold">{`Level ${depth + 1} Child #${index + 1}`}</Text>
+          <Button
+            appearance="subtle"
+            aria-label="Remove child table"
+            icon={<Delete24Regular />}
+            onClick={() => removeChildConfig(config, parentConfig)}
+          />
+        </div>
+
+        <Dropdown
+          placeholder="Select child table"
+          selectedOptions={config.childTableLogicalName ? [config.childTableLogicalName] : []}
+          button={<span>{selectedChildTableText || "Select child table"}</span>}
+          onOptionSelect={async (_, data) => {
+            const nextChildTable = data.optionValue || "";
+            if (!nextChildTable || nextChildTable === config.childTableLogicalName) {
+              return;
+            }
+            config.setChildTable(nextChildTable);
+            config.setLookupField("");
+            config.setExcludedFields([]);
+            config.setChildConfigs([]);
+            clearLookupOptionsForTree(config);
+            await ensureChildMetadataForParent(nextChildTable);
+            await loadLookupFieldOptions(config, parentTableLogicalName);
+          }}
+        >
+          {availableChildTables.map((table) => (
+            <Option
+              key={table.logicalName}
+              value={table.logicalName}
+              text={`${table.displayName || table.logicalName} (${table.logicalName})`}
+            >
+              {table.displayName || table.logicalName}{" "}
+              <Text size={100} style={{ color: "var(--colorNeutralForeground3)" }}>
+                ({table.logicalName})
+              </Text>
+            </Option>
+          ))}
+          {availableChildTables.length === 0 && (
+            <Option disabled value="__no-child-tables">
+              No related child tables available
+            </Option>
+          )}
+        </Dropdown>
+
+        <Dropdown
+          placeholder="Select parent lookup field"
+          selectedOptions={config.parentLookupFieldLogicalName ? [config.parentLookupFieldLogicalName] : []}
+          button={<span>{selectedLookupText || "Select parent lookup field"}</span>}
+          onOptionSelect={(_, data) => {
+            const nextLookupField = data.optionValue || "";
+            if (!nextLookupField) {
+              return;
+            }
+            const selectedField = lookupOptions.find((f) => f.logicalName === nextLookupField);
+            config.setLookupField(nextLookupField, selectedField?.schemaName);
+          }}
+          disabled={!config.childTableLogicalName}
+        >
+          {lookupOptions.map((field) => (
+            <Option
+              key={field.logicalName}
+              value={field.logicalName}
+              text={`${field.displayName || field.logicalName} (${field.logicalName})`}
+            >
+              {field.displayName || field.logicalName}
+              <Text size={100} style={{ color: "var(--colorNeutralForeground3)" }}>
+                ({field.logicalName})
+              </Text>
+            </Option>
+          ))}
+          {config.childTableLogicalName && lookupOptions.length === 0 && (
+            <Option disabled value="__no-parent-lookups">
+              No lookup field references the selected parent table
+            </Option>
+          )}
+        </Dropdown>
+
+        <div>
+          <Text size={200} weight="semibold">
+            Exclude Child Fields
+          </Text>
+          <div
+            style={{
+              marginTop: "6px",
+              maxHeight: "150px",
+              overflowY: "auto",
+              display: "flex",
+              flexDirection: "column",
+              gap: "5px",
+            }}
+          >
+            {visibleChildFields.map((field) => {
+              const checked = config.excludedFields.includes(field.logicalName);
+              return (
+                <div
+                  key={`${config.id}-${field.logicalName}`}
+                  style={{
+                    padding: "5px 6px",
+                    borderRadius: "6px",
+                    background: checked ? "rgba(255, 99, 71, 0.15)" : "transparent",
+                  }}
+                >
+                  <Checkbox
+                    checked={checked}
+                    onChange={(_, data) => toggleChildSkip(config, field.logicalName, !!data.checked)}
+                    label={`${field.displayName || field.logicalName} (${field.logicalName})`}
+                  />
+                </div>
+              );
+            })}
+            {selectedChildTable && visibleChildFields.length === 0 && (
+              <Text size={200}>No eligible child fields to exclude (primary and key fields are hidden).</Text>
+            )}
+          </div>
+        </div>
+
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <Text size={200}>Configure descendants (grandchildren and deeper)</Text>
+          <Button
+            icon={<Add24Regular />}
+            onClick={() => void addNestedChildConfig(config)}
+            disabled={!config.childTableLogicalName}
+          >
+            Add Nested Child
+          </Button>
+        </div>
+
+        {config.childConfigs.length > 0 && (
+          <div style={{ display: "flex", flexDirection: "column", gap: "10px" }}>
+            {config.childConfigs.map((childConfig, childIndex) =>
+              renderChildConfigCard(childConfig, childIndex, config.childTableLogicalName, depth + 1, config),
+            )}
+          </div>
+        )}
+      </div>
+    );
   };
 
   const handleRunCloneClick = () => {
@@ -289,6 +614,122 @@ export const ClonePanel = observer((props: ClonePanelProps): React.JSX.Element =
     }
   };
 
+  const saveCloneConfiguration = async (): Promise<void> => {
+    if (!vm.selectedTable) {
+      window.toolboxAPI.utils.showNotification({
+        title: "No Table Selected",
+        body: "Please select a table before saving clone configuration.",
+        type: "warning",
+      });
+      return;
+    }
+
+    const config = {
+      table: {
+        logicalName: vm.selectedTable.logicalName,
+      },
+      clone: {
+        skippedFields: [...vm.cloneSkippedFields],
+        childConfigs: vm.cloneChildConfigs.map(serializeCloneChildConfig),
+      },
+    };
+
+    onLog("Saving clone configuration...", "info");
+
+    try {
+      await window.toolboxAPI.fileSystem.saveFile(
+        `${vm.selectedTable.logicalName}-CloneConfig.json`,
+        JSON.stringify(config, null, 2),
+      );
+      onLog("Clone configuration saved successfully", "success");
+      await window.toolboxAPI.utils.showNotification({
+        title: "Clone Configuration Saved",
+        body: "Clone configuration has been saved successfully.",
+        type: "success",
+      });
+    } catch (error) {
+      onLog(`Error saving clone configuration: ${error}`, "error");
+      await window.toolboxAPI.utils.showNotification({
+        title: "Error Saving Clone Configuration",
+        body: `An error occurred while saving clone configuration: ${error}`,
+        type: "error",
+      });
+    }
+  };
+
+  const loadCloneConfiguration = async (): Promise<void> => {
+    try {
+      const filePath = await window.toolboxAPI.fileSystem.selectPath({
+        type: "file",
+        title: "Select Clone Configuration File",
+        filters: [
+          { name: "JSON Files", extensions: ["json"] },
+          { name: "All Files", extensions: ["*"] },
+        ],
+      });
+
+      if (!filePath) {
+        return;
+      }
+
+      onLog(`Selected clone configuration file: ${filePath}`, "info");
+      const content = await window.toolboxAPI.fileSystem.readText(filePath);
+      const config = JSON.parse(content);
+
+      if (!config || typeof config !== "object") {
+        throw new Error("Invalid clone configuration: must be an object");
+      }
+      if (!config.table || typeof config.table !== "object") {
+        throw new Error("Invalid clone configuration: missing table section");
+      }
+      if (!config.table.logicalName || typeof config.table.logicalName !== "string") {
+        throw new Error("Invalid clone configuration: missing table.logicalName");
+      }
+      if (!config.clone || typeof config.clone !== "object") {
+        throw new Error("Invalid clone configuration: missing clone section");
+      }
+
+      if (vm.tables.length === 0) {
+        vm.tables = await dvSvc.getTables();
+      }
+
+      const table = vm.tables.find((t) => t.logicalName === config.table.logicalName);
+      if (!table) {
+        throw new Error(`Table '${config.table.logicalName}' was not found in the current environment`);
+      }
+
+      vm.selectedTable = table;
+      if (!vm.selectedTable.fields || vm.selectedTable.fields.length === 0) {
+        vm.selectedTable.fields = await dvSvc.getFields(vm.selectedTable.logicalName);
+      }
+
+      vm.cloneSkippedFields = Array.isArray(config.clone.skippedFields)
+        ? config.clone.skippedFields.filter((f: unknown) => typeof f === "string")
+        : [];
+
+      vm.cloneChildConfigs = Array.isArray(config.clone.childConfigs)
+        ? config.clone.childConfigs
+            .map((child: any) => deserializeCloneChildConfig(child))
+            .filter((child: CloneChildConfig | undefined): child is CloneChildConfig => !!child)
+        : [];
+
+      setActiveTab("children");
+      onLog("Clone configuration loaded successfully", "success");
+      await window.toolboxAPI.utils.showNotification({
+        title: "Clone Configuration Loaded",
+        body: "Clone configuration has been loaded successfully.",
+        type: "success",
+      });
+    } catch (error) {
+      onLog(`Error loading clone configuration: ${error}`, "error");
+      await window.toolboxAPI.utils.showNotification({
+        title: "Error Loading Clone Configuration",
+        body: `An error occurred while loading clone configuration: ${error}`,
+        type: "error",
+      });
+    }
+  };
+
   const onTabSelect = (_event: SelectTabEvent, data: SelectTabData) => {
     setActiveTab(data.value as "exclude" | "children");
   };
@@ -303,6 +744,24 @@ export const ClonePanel = observer((props: ClonePanelProps): React.JSX.Element =
       >
         <DrawerHeader style={{ paddingBottom: "8px" }}>
           <DrawerHeaderTitle>Clone Settings</DrawerHeaderTitle>
+          <div style={{ display: "flex", justifyContent: "flex-end", gap: "8px", marginTop: "8px" }}>
+            <Button
+              icon={<FolderOpen24Regular />}
+              appearance="secondary"
+              onClick={() => void loadCloneConfiguration()}
+              disabled={cloning}
+            >
+              Load Clone Config
+            </Button>
+            <Button
+              icon={<Save24Regular />}
+              appearance="secondary"
+              onClick={() => void saveCloneConfiguration()}
+              disabled={cloning || !vm.selectedTable}
+            >
+              Save Clone Config
+            </Button>
+          </div>
           <TabList selectedValue={activeTab} onTabSelect={onTabSelect} style={{ marginTop: "8px", width: "100%" }}>
             <Tab value="exclude">Exclude Fields</Tab>
             <Tab value="children">Child Tables</Tab>
@@ -393,166 +852,9 @@ export const ClonePanel = observer((props: ClonePanelProps): React.JSX.Element =
                           minHeight: 0,
                         }}
                       >
-                        {vm.cloneChildConfigs.map((config, index) => {
-                          const selectedChildTable = vm.tables.find(
-                            (t) => t.logicalName === config.childTableLogicalName,
-                          );
-                          const childFields = selectedChildTable?.fields || [];
-                          const childKeySet = new Set(
-                            selectedChildTable ? keyFieldsByTable[selectedChildTable.logicalName] || [] : [],
-                          );
-                          const lookupOptions = lookupFieldOptions[config.id] || [];
-                          const selectedLookup = lookupOptions.find(
-                            (f) => f.logicalName === config.parentLookupFieldLogicalName,
-                          );
-                          const selectedChildTableText = selectedChildTable
-                            ? `${selectedChildTable.displayName || selectedChildTable.logicalName} (${selectedChildTable.logicalName})`
-                            : config.childTableLogicalName || undefined;
-                          const selectedLookupText = selectedLookup
-                            ? `${selectedLookup.displayName || selectedLookup.logicalName} (${selectedLookup.logicalName})`
-                            : config.parentLookupFieldLogicalName || undefined;
-                          const visibleChildFields = childFields.filter(
-                            (f) =>
-                              f.logicalName !== selectedChildTable?.primaryIdAttribute &&
-                              !childKeySet.has(f.logicalName),
-                          );
-
-                          return (
-                            <div
-                              key={config.id}
-                              style={{
-                                border: "1px solid var(--colorNeutralStroke2)",
-                                borderRadius: "8px",
-                                padding: "10px",
-                                display: "flex",
-                                flexDirection: "column",
-                                gap: "10px",
-                              }}
-                            >
-                              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-                                <Text weight="semibold">Child Table #{index + 1}</Text>
-                                <Button
-                                  appearance="subtle"
-                                  aria-label="Remove child table"
-                                  icon={<Delete24Regular />}
-                                  onClick={() => removeChildConfig(config)}
-                                />
-                              </div>
-
-                              <Dropdown
-                                placeholder="Select child table"
-                                selectedOptions={config.childTableLogicalName ? [config.childTableLogicalName] : []}
-                                button={<span>{selectedChildTableText || "Select child table"}</span>}
-                                onOptionSelect={async (_, data) => {
-                                  const nextChildTable = data.optionValue || "";
-                                  if (!nextChildTable || nextChildTable === config.childTableLogicalName) {
-                                    return;
-                                  }
-                                  config.setChildTable(nextChildTable);
-                                  config.setLookupField("");
-                                  config.setExcludedFields([]);
-                                  await loadLookupFieldOptions(config);
-                                }}
-                              >
-                                {childTables.map((table) => (
-                                  <Option
-                                    key={table.logicalName}
-                                    value={table.logicalName}
-                                    text={`${table.displayName || table.logicalName} (${table.logicalName})`}
-                                  >
-                                    {table.displayName || table.logicalName}{" "}
-                                    <Text size={100} style={{ color: "var(--colorNeutralForeground3)" }}>
-                                      ({table.logicalName})
-                                    </Text>
-                                  </Option>
-                                ))}
-                                {childTables.length === 0 && (
-                                  <Option disabled value="__no-child-tables">
-                                    No related child tables available
-                                  </Option>
-                                )}
-                              </Dropdown>
-
-                              <Dropdown
-                                placeholder="Select parent lookup field"
-                                selectedOptions={
-                                  config.parentLookupFieldLogicalName ? [config.parentLookupFieldLogicalName] : []
-                                }
-                                button={<span>{selectedLookupText || "Select parent lookup field"}</span>}
-                                onOptionSelect={(_, data) => {
-                                  const nextLookupField = data.optionValue || "";
-                                  if (!nextLookupField) {
-                                    return;
-                                  }
-                                  const selectedField = lookupOptions.find((f) => f.logicalName === nextLookupField);
-                                  config.setLookupField(nextLookupField, selectedField?.schemaName);
-                                }}
-                                disabled={!config.childTableLogicalName}
-                              >
-                                {lookupOptions.map((field) => (
-                                  <Option
-                                    key={field.logicalName}
-                                    value={field.logicalName}
-                                    text={`${field.displayName || field.logicalName} (${field.logicalName})`}
-                                  >
-                                    {field.displayName || field.logicalName}
-                                    <Text size={100} style={{ color: "var(--colorNeutralForeground3)" }}>
-                                      ({field.logicalName})
-                                    </Text>
-                                  </Option>
-                                ))}
-                                {config.childTableLogicalName && lookupOptions.length === 0 && (
-                                  <Option disabled value="__no-parent-lookups">
-                                    No lookup field references the selected parent table
-                                  </Option>
-                                )}
-                              </Dropdown>
-
-                              <div>
-                                <Text size={200} weight="semibold">
-                                  Exclude Child Fields
-                                </Text>
-                                <div
-                                  style={{
-                                    marginTop: "6px",
-                                    maxHeight: "150px",
-                                    overflowY: "auto",
-                                    display: "flex",
-                                    flexDirection: "column",
-                                    gap: "5px",
-                                  }}
-                                >
-                                  {visibleChildFields.map((field) => {
-                                    const checked = config.excludedFields.includes(field.logicalName);
-                                    return (
-                                      <div
-                                        key={`${config.id}-${field.logicalName}`}
-                                        style={{
-                                          padding: "5px 6px",
-                                          borderRadius: "6px",
-                                          background: checked ? "rgba(255, 99, 71, 0.15)" : "transparent",
-                                        }}
-                                      >
-                                        <Checkbox
-                                          checked={checked}
-                                          onChange={(_, data) =>
-                                            toggleChildSkip(config, field.logicalName, !!data.checked)
-                                          }
-                                          label={`${field.displayName || field.logicalName} (${field.logicalName})`}
-                                        />
-                                      </div>
-                                    );
-                                  })}
-                                  {selectedChildTable && visibleChildFields.length === 0 && (
-                                    <Text size={200}>
-                                      No eligible child fields to exclude (primary and key fields are hidden).
-                                    </Text>
-                                  )}
-                                </div>
-                              </div>
-                            </div>
-                          );
-                        })}
+                        {vm.cloneChildConfigs.map((config, index) =>
+                          renderChildConfigCard(config, index, vm.selectedTable?.logicalName || "", 0),
+                        )}
                       </div>
                     )}
                   </div>
@@ -583,7 +885,7 @@ export const ClonePanel = observer((props: ClonePanelProps): React.JSX.Element =
                 !vm.selectedTable ||
                 vm.selectedRows.length === 0 ||
                 loadingPanelData ||
-                vm.cloneChildConfigs.some((cfg) => !!cfg.childTableLogicalName && !cfg.parentLookupFieldLogicalName)
+                hasInvalidChildConfig(vm.cloneChildConfigs)
               }
             >
               {cloning ? "Cloning..." : "Run Clone"}

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -14,7 +14,7 @@ import {
   RowSelectionModule,
   SelectionChangedEvent,
 } from "ag-grid-community";
-import { AgGridReact } from "ag-grid-react";
+import { AgGridReact, CustomCellRendererProps } from "ag-grid-react";
 
 ModuleRegistry.registerModules([
   TextFilterModule,
@@ -179,6 +179,9 @@ export const DataGrid = observer((props: DataGridProps): React.JSX.Element => {
     wrapText: true,
     autoHeight: true,
     width: 100,
+    cellRenderer: (params: CustomCellRendererProps<any>) => (
+      <div className="bds-grid-line-clamp">{params.valueFormatted ?? String(params.value ?? "")}</div>
+    ),
   };
 
   const rowSelection = React.useMemo<RowSelectionOptions | "single" | "multiple">(() => {

--- a/src/components/UpdateAddField.tsx
+++ b/src/components/UpdateAddField.tsx
@@ -59,6 +59,7 @@ function renderIcon(type: string = ""): React.JSX.Element {
       icon = <SlideSearchRegular style={{ fontSize: "24px", verticalAlign: "Center" }} />;
       break;
     case "Picklist":
+    case "MultiSelectPicklist":
     case "State":
     case "Status":
       icon = <TextBulletListSquareSearchRegular style={{ fontSize: "24px", verticalAlign: "Center" }} />;

--- a/src/components/UpdateList.tsx
+++ b/src/components/UpdateList.tsx
@@ -100,7 +100,29 @@ export const UpdateList = observer((props: UpdateListProps): React.JSX.Element =
   const { dvSvc, vm, onLog } = props;
 
   const cols: ColDef<UpdateColumn>[] = [
-    { field: "column.displayName", headerName: "Field Name", flex: 2 },
+    {
+      field: "column.displayName",
+      headerName: "Field Name",
+      flex: 2,
+      cellRenderer: (params: CustomCellRendererProps<UpdateColumn>) => {
+        const fieldName = params.data?.column.displayName || "";
+        return (
+          <div
+            title={fieldName}
+            style={{
+              display: "-webkit-box",
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: "vertical",
+              overflow: "hidden",
+              lineHeight: "1.2",
+              maxHeight: "2.4em",
+            }}
+          >
+            {fieldName}
+          </div>
+        );
+      },
+    },
     {
       field: "newValue",
       headerName: "New Value",

--- a/src/components/UpdateValue.tsx
+++ b/src/components/UpdateValue.tsx
@@ -41,6 +41,10 @@ export const UpdateValue = observer((props: UpdateValueProps): React.JSX.Element
     }
   };
 
+  const onMultiOptionSelected = (selectedOptions: string[]) => {
+    updateColumn.selectedSelections = selectValues.filter((value) => selectedOptions.includes(value.value));
+  };
+
   const setChoiceValues = () => {
     const choices = updateColumn.column.choiceValues || [];
     if (updateColumn.column.type === "Status") {
@@ -62,6 +66,7 @@ export const UpdateValue = observer((props: UpdateValueProps): React.JSX.Element
     const getFieldParameters = async () => {
       switch (updateColumn.column?.type) {
         case "Picklist":
+        case "MultiSelectPicklist":
         case "State":
         case "Status":
           if (updateColumn.column.choiceValues && updateColumn.column.choiceValues.length > 0) {
@@ -106,6 +111,8 @@ export const UpdateValue = observer((props: UpdateValueProps): React.JSX.Element
     }
   }, [updateColumn.column.type, updateColumn.column.choiceValues, selectedStateValue]);
 
+  const selectedMultiLabels = (updateColumn.selectedSelections || []).map((selection) => selection.label).join(", ");
+
   const pickList = (
     <Combobox
       style={{ width: "100%" }}
@@ -118,6 +125,26 @@ export const UpdateValue = observer((props: UpdateValueProps): React.JSX.Element
     >
       {selectValues.map((value, index) => (
         <Option key={index} value={value.value}>
+          {value.label}
+        </Option>
+      ))}
+    </Combobox>
+  );
+
+  const multiPickList = (
+    <Combobox
+      style={{ width: "100%" }}
+      multiselect
+      placeholder="Select Options"
+      selectedOptions={(updateColumn.selectedSelections || []).map((selection) => selection.value)}
+      value={selectedMultiLabels}
+      onOptionSelect={(_, data) => {
+        onMultiOptionSelected(data.selectedOptions || []);
+      }}
+      disabled={selectValues.length === 0}
+    >
+      {selectValues.map((value, index) => (
+        <Option key={index} value={value.value} text={value.label}>
           {value.label}
         </Option>
       ))}
@@ -192,9 +219,10 @@ export const UpdateValue = observer((props: UpdateValueProps): React.JSX.Element
       {updateColumn.setStatus === "Fixed" && (
         <>
           {(updateColumn.column.type === "Picklist" ||
+            updateColumn.column.type === "MultiSelectPicklist" ||
             updateColumn.column.type === "State" ||
             updateColumn.column.type === "Status") &&
-            pickList}
+            (updateColumn.column.type === "MultiSelectPicklist" ? multiPickList : pickList)}
           {(updateColumn.column.type === "String" || updateColumn.column.type === "Memo") && stringEditor}
           {updateColumn.column.type === "Boolean" && booleanEditor}
           {(updateColumn.column.type === "Money" ||

--- a/src/components/UpdateValue.tsx
+++ b/src/components/UpdateValue.tsx
@@ -19,6 +19,8 @@ interface UpdateValueProps {
 export const UpdateValue = observer((props: UpdateValueProps): React.JSX.Element => {
   const { updateColumn, dvSvc, vm, onLog } = props;
   const [selectValues, setPicklistValues] = React.useState<SelectionValue[]>([]);
+  const selectedStateValue = vm.updateCols.find((col) => col.column.logicalName === "statecode")
+    ?.selectedSelections?.[0]?.value;
 
   const [lookupPopupOpen, setLookupPopupOpen] = React.useState<boolean>(false);
 
@@ -86,6 +88,23 @@ export const UpdateValue = observer((props: UpdateValueProps): React.JSX.Element
     };
     getFieldParameters();
   }, [updateColumn.column, dvSvc, vm.selectedTable?.logicalName]);
+
+  React.useEffect(() => {
+    if (updateColumn.column.type !== "Status") {
+      return;
+    }
+
+    setChoiceValues();
+
+    const selectedStatus = updateColumn.selectedSelections?.[0];
+    if (
+      selectedStatus &&
+      selectedStateValue &&
+      selectedStatus.parentState?.toString() !== selectedStateValue
+    ) {
+      updateColumn.selectedSelections = [];
+    }
+  }, [updateColumn.column.type, updateColumn.column.choiceValues, selectedStateValue]);
 
   const pickList = (
     <Combobox

--- a/src/index.css
+++ b/src/index.css
@@ -272,6 +272,16 @@ body {
   min-height: 50px;
 }
 
+.bds-grid-line-clamp {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 4;
+  overflow: hidden;
+  white-space: normal;
+  line-height: 1.2rem;
+  max-height: 4.8rem;
+}
+
 .output:empty::before {
   content: "No output yet...";
   color: #666;

--- a/src/model/UpdateColumn.tsx
+++ b/src/model/UpdateColumn.tsx
@@ -66,7 +66,7 @@ export class UpdateColumn {
         case "Picklist":
           return this.selectedSelections?.[0].value;
         case "MultiSelectPicklist":
-          return this.selectedSelections?.map((selection) => parseInt(selection.value, 10));
+          return this.selectedSelections?.map((selection) => selection.value).join(",");
         case "State":
         case "Status":
           return this.selectedSelections?.[0].value;

--- a/src/model/UpdateColumn.tsx
+++ b/src/model/UpdateColumn.tsx
@@ -66,7 +66,7 @@ export class UpdateColumn {
         case "Picklist":
           return this.selectedSelections?.[0].value;
         case "MultiSelectPicklist":
-          return this.selectedSelections?.map((selection) => selection.value).join(",");
+          return this.selectedSelections?.map((selection) => parseInt(selection.value, 10));
         case "State":
         case "Status":
           return this.selectedSelections?.[0].value;

--- a/src/model/UpdateColumn.tsx
+++ b/src/model/UpdateColumn.tsx
@@ -20,7 +20,15 @@ export class UpdateColumn {
   }
 
   get formattedNewValue(): string {
-    if (this.column.type === "Picklist" || this.column.type === "State" || this.column.type === "Status") {
+    if (
+      this.column.type === "Picklist" ||
+      this.column.type === "MultiSelectPicklist" ||
+      this.column.type === "State" ||
+      this.column.type === "Status"
+    ) {
+      if (this.selectedSelections && this.selectedSelections.length > 0) {
+        return this.selectedSelections.map((selection) => selection.label).join(", ");
+      }
       return this.oldSelValues ? this.oldSelValues.join(", ") : "";
     }
     return this.newValue !== undefined && this.newValue !== null ? String(this.newValue) : "";
@@ -30,6 +38,7 @@ export class UpdateColumn {
     if (this.setStatus === "Fixed") {
       if (
         this.column.type === "Picklist" ||
+        this.column.type === "MultiSelectPicklist" ||
         this.column.type === "State" ||
         this.column.type === "Status" ||
         this.column.type === "Lookup" ||
@@ -55,6 +64,9 @@ export class UpdateColumn {
         case "Owner":
           return `/${this.selectedSelections?.[0].ownerTable}(${this.selectedSelections?.[0].value})`;
         case "Picklist":
+          return this.selectedSelections?.[0].value;
+        case "MultiSelectPicklist":
+          return this.selectedSelections?.map((selection) => selection.value).join(",");
         case "State":
         case "Status":
           return this.selectedSelections?.[0].value;

--- a/src/model/vm.tsx
+++ b/src/model/vm.tsx
@@ -159,6 +159,7 @@ export class Column {
       case "Owner":
         return `_${this.logicalName}_value@OData.Community.Display.V1.FormattedValue`;
       case "Picklist":
+      case "MultiSelectPicklist":
       case "State":
       case "Status":
         return `${this.logicalName}@OData.Community.Display.V1.FormattedValue`;

--- a/src/model/vm.tsx
+++ b/src/model/vm.tsx
@@ -33,6 +33,7 @@ export class CloneChildConfig {
   parentLookupFieldLogicalName: string = "";
   parentLookupFieldSchemaName: string = "";
   excludedFields: string[] = [];
+  childConfigs: CloneChildConfig[] = [];
 
   constructor(init?: Partial<CloneChildConfig>) {
     makeObservable(this, {
@@ -40,9 +41,13 @@ export class CloneChildConfig {
       parentLookupFieldLogicalName: observable,
       parentLookupFieldSchemaName: observable,
       excludedFields: observable,
+      childConfigs: observable,
       setChildTable: action,
       setLookupField: action,
       setExcludedFields: action,
+      setChildConfigs: action,
+      addChildConfig: action,
+      removeChildConfig: action,
     });
     Object.assign(this, init);
   }
@@ -56,6 +61,18 @@ export class CloneChildConfig {
   }
   setExcludedFields(value: string[]) {
     this.excludedFields = value;
+  }
+
+  setChildConfigs(value: CloneChildConfig[]) {
+    this.childConfigs = value;
+  }
+
+  addChildConfig(config?: CloneChildConfig) {
+    this.childConfigs.push(config || new CloneChildConfig());
+  }
+
+  removeChildConfig(config: CloneChildConfig) {
+    this.childConfigs = this.childConfigs.filter((item) => item !== config);
   }
 }
 

--- a/src/utils/dataverseService.tsx
+++ b/src/utils/dataverseService.tsx
@@ -544,7 +544,7 @@ export class dvService {
       }
 
       const url = `EntityDefinitions(LogicalName='${tableLogicalName}')/Attributes(LogicalName='${column.logicalName}')/Microsoft.Dynamics.CRM.${attributeMeta}?$select=LogicalName&$expand=OptionSet`;
-      
+
       const picklistMeta: any = await this.dvApi.queryData(url);
       this.onLog(`Picklist metadata loaded for ${tableLogicalName}.${column.logicalName}`, "info");
       const options = picklistMeta.OptionSet?.Options || [];

--- a/src/utils/dataverseService.tsx
+++ b/src/utils/dataverseService.tsx
@@ -484,20 +484,27 @@ export class dvService {
     }
 
     try {
-      const url = `EntityDefinitions(LogicalName='${tableLogicalName}')/Attributes?$select=LogicalName,SchemaName,DisplayName,AttributeType,IsPrimaryId,IsCustomAttribute,IsValidForCreate&$filter=IsValidForUpdate eq true`;
+      const url = `EntityDefinitions(LogicalName='${tableLogicalName}')/Attributes?$select=LogicalName,SchemaName,DisplayName,AttributeType,AttributeTypeName,IsPrimaryId,IsCustomAttribute,IsValidForCreate&$filter=IsValidForUpdate eq true`;
       const metadataAlt: any = await this.dvApi.queryData(url);
       const fields = (Array.isArray(metadataAlt?.value) ? metadataAlt.value : [])
         .map(
-          (attr: any) =>
-            new Column(
+          (attr: any) => {
+            const attributeTypeName = attr.AttributeTypeName?.Value;
+            const resolvedType =
+              attr.AttributeType === "Virtual" && attributeTypeName === "MultiSelectPicklistType"
+                ? "MultiSelectPicklist"
+                : attr.AttributeType;
+
+            return new Column(
               attr.LogicalName,
               attr.DisplayName?.UserLocalizedLabel?.Label || attr.LogicalName,
-              attr.AttributeType,
+              resolvedType,
               attr.IsPrimaryId,
               attr.SchemaName,
               !!attr.IsCustomAttribute,
               attr.IsValidForCreate !== false,
-            ),
+            );
+          },
         )
         .sort((a: any, b: any) => a.displayName.localeCompare(b.displayName));
 
@@ -522,6 +529,9 @@ export class dvService {
       switch (column.type) {
         case "Picklist":
           attributeMeta = "PicklistAttributeMetadata";
+          break;
+        case "MultiSelectPicklist":
+          attributeMeta = "MultiSelectPicklistAttributeMetadata";
           break;
         case "State":
           attributeMeta = "StateAttributeMetadata";

--- a/src/utils/dataverseService.tsx
+++ b/src/utils/dataverseService.tsx
@@ -210,47 +210,60 @@ export class dvService {
       }
     }
 
-    const effectiveChildConfigs = childConfigs.filter(
-      (cfg) => cfg.childTableLogicalName && cfg.parentLookupFieldLogicalName,
-    );
-
-    if (effectiveChildConfigs.length > 0 && !parentTable.setName) {
-      const msg = `Entity set name not found for parent table '${parentTable.logicalName}'. Child records cannot be cloned.`;
-      this.onLog(msg, "error");
-      throw new Error(msg);
-    }
-
-    for (const childConfig of effectiveChildConfigs) {
-      const childTable = allTables.find((t) => t.logicalName === childConfig.childTableLogicalName);
-      if (!childTable) {
-        this.onLog(`Child table not found: ${childConfig.childTableLogicalName}`, "warning");
-        continue;
+    const cloneChildHierarchy = async (
+      sourceParentTable: Table,
+      parentIdMappings: Map<string, string>,
+      configs: CloneChildConfig[],
+    ): Promise<void> => {
+      const effectiveConfigs = configs.filter((cfg) => cfg.childTableLogicalName && cfg.parentLookupFieldLogicalName);
+      if (effectiveConfigs.length === 0) {
+        return;
       }
 
-      if (!childTable.fields || childTable.fields.length === 0) {
-        childTable.fields = await this.getFields(childTable.logicalName);
+      if (!sourceParentTable.setName) {
+        const msg = `Entity set name not found for parent table '${sourceParentTable.logicalName}'. Child records cannot be cloned.`;
+        this.onLog(msg, "error");
+        throw new Error(msg);
       }
 
-      const childAlternateKeyFields = await getCachedAlternateKeyFields(childTable.logicalName);
+      for (const childConfig of effectiveConfigs) {
+        const childTable = allTables.find((t) => t.logicalName === childConfig.childTableLogicalName);
+        if (!childTable) {
+          this.onLog(`Child table not found: ${childConfig.childTableLogicalName}`, "warning");
+          continue;
+        }
 
-      const childSkippedSet = new Set<string>([
-        ...childConfig.excludedFields,
-        childTable.primaryIdAttribute,
-        childConfig.parentLookupFieldLogicalName,
-        ...childAlternateKeyFields,
-      ]);
+        if (!childTable.fields || childTable.fields.length === 0) {
+          childTable.fields = await this.getFields(childTable.logicalName);
+        }
 
-      const childCloneFields = childTable.fields
-        .filter((field) => !childSkippedSet.has(field.logicalName))
-        .filter((field) => this.isCloneSupportedFieldType(field))
-        .filter((field) => field.logicalName !== childTable.primaryIdAttribute)
-        .filter((field) => field.isValidForCreate);
+        const childAlternateKeyFields = await getCachedAlternateKeyFields(childTable.logicalName);
+        const childSkippedSet = new Set<string>([
+          ...childConfig.excludedFields,
+          childTable.primaryIdAttribute,
+          childConfig.parentLookupFieldLogicalName,
+          ...childAlternateKeyFields,
+        ]);
 
-      const childFieldNames = childCloneFields.map((field) => field.logicalName);
+        const childCloneFields = childTable.fields
+          .filter((field) => !childSkippedSet.has(field.logicalName))
+          .filter((field) => this.isCloneSupportedFieldType(field))
+          .filter((field) => field.logicalName !== childTable.primaryIdAttribute)
+          .filter((field) => field.isValidForCreate);
 
-      for (const [oldParentId, newParentId] of parentIdMap.entries()) {
-        const childAttrsXml = childFieldNames.map((f) => `<attribute name='${f}'/>`).join("");
-        const childFetchXml = `<fetch>
+        const childFieldNames = childCloneFields.map((field) => field.logicalName);
+        const parentLookupField = childTable.fields.find(
+          (field) => field.logicalName === childConfig.parentLookupFieldLogicalName,
+        );
+        const lookupBindName = parentLookupField?.isCustom
+          ? childConfig.parentLookupFieldSchemaName || childConfig.parentLookupFieldLogicalName
+          : childConfig.parentLookupFieldLogicalName;
+
+        const childIdMappings = new Map<string, string>();
+
+        for (const [oldParentId, newParentId] of parentIdMappings.entries()) {
+          const childAttrsXml = childFieldNames.map((f) => `<attribute name='${f}'/>`).join("");
+          const childFetchXml = `<fetch>
   <entity name="${childTable.logicalName}">
     ${childAttrsXml}
     <attribute name="${childTable.primaryIdAttribute}"/>
@@ -260,27 +273,34 @@ export class dvService {
   </entity>
 </fetch>`;
 
-        const childData = await this.dvApi.fetchXmlQuery(childFetchXml);
-        const childRecords = Array.isArray(childData?.value) ? childData.value : [];
-        for (const childRecord of childRecords) {
-          const childPayload = await this.createClonePayloadFromRecord(
-            childTable.logicalName,
-            childRecord,
-            childCloneFields,
-            allTables,
-          );
-          const parentLookupField = childTable.fields.find(
-            (field) => field.logicalName === childConfig.parentLookupFieldLogicalName,
-          );
-          const lookupBindName = parentLookupField?.isCustom
-            ? childConfig.parentLookupFieldSchemaName || childConfig.parentLookupFieldLogicalName
-            : childConfig.parentLookupFieldLogicalName;
-          childPayload[`${lookupBindName}@odata.bind`] = `/${parentTable.setName}(${newParentId})`;
-          await this.dvApi.create(childTable.logicalName, childPayload);
-          childCloned += 1;
+          const childData = await this.dvApi.fetchXmlQuery(childFetchXml);
+          const childRecords = Array.isArray(childData?.value) ? childData.value : [];
+          for (const childRecord of childRecords) {
+            const oldChildId = childRecord[childTable.primaryIdAttribute];
+            if (!oldChildId) {
+              continue;
+            }
+
+            const childPayload = await this.createClonePayloadFromRecord(
+              childTable.logicalName,
+              childRecord,
+              childCloneFields,
+              allTables,
+            );
+            childPayload[`${lookupBindName}@odata.bind`] = `/${sourceParentTable.setName}(${newParentId})`;
+            const createdChild = await this.dvApi.create(childTable.logicalName, childPayload);
+            childIdMappings.set(String(oldChildId), createdChild.id);
+            childCloned += 1;
+          }
+        }
+
+        if (childConfig.childConfigs.length > 0 && childIdMappings.size > 0) {
+          await cloneChildHierarchy(childTable, childIdMappings, childConfig.childConfigs);
         }
       }
-    }
+    };
+
+    await cloneChildHierarchy(parentTable, parentIdMap, childConfigs);
 
     this.onLog(`Clone completed. Parent records: ${parentCloned}, child records: ${childCloned}`, "success");
     return { parentCloned, childCloned };
@@ -514,9 +534,9 @@ export class dvService {
       }
 
       const url = `EntityDefinitions(LogicalName='${tableLogicalName}')/Attributes(LogicalName='${column.logicalName}')/Microsoft.Dynamics.CRM.${attributeMeta}?$select=LogicalName&$expand=OptionSet`;
-
+      
       const picklistMeta: any = await this.dvApi.queryData(url);
-
+      console.log(`Picklist metadata for ${tableLogicalName}.${column.logicalName}:`, picklistMeta);  
       const options = picklistMeta.OptionSet?.Options || [];
       const values: SelectionValue[] = options.map((opt: any) => ({
         label: opt.Label?.UserLocalizedLabel?.Label || "",

--- a/src/utils/dataverseService.tsx
+++ b/src/utils/dataverseService.tsx
@@ -546,7 +546,7 @@ export class dvService {
       const url = `EntityDefinitions(LogicalName='${tableLogicalName}')/Attributes(LogicalName='${column.logicalName}')/Microsoft.Dynamics.CRM.${attributeMeta}?$select=LogicalName&$expand=OptionSet`;
       
       const picklistMeta: any = await this.dvApi.queryData(url);
-      console.log(`Picklist metadata for ${tableLogicalName}.${column.logicalName}:`, picklistMeta);  
+      this.onLog(`Picklist metadata loaded for ${tableLogicalName}.${column.logicalName}`, "info");
       const options = picklistMeta.OptionSet?.Options || [];
       const values: SelectionValue[] = options.map((opt: any) => ({
         label: opt.Label?.UserLocalizedLabel?.Label || "",

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -46,6 +46,7 @@ export class utilService {
     return new Promise<void>(async (resolve, reject) => {
       switch (column.type) {
         case "Picklist":
+        case "MultiSelectPicklist":
         case "State":
         case "Status":
           if (!column.choiceValues || column.choiceValues.length === 0) {


### PR DESCRIPTION
Two bugs introduced with MultiSelectPicklist support, flagged in code review.

## Changes

- **`src/utils/dataverseService.tsx`** — `getChoiceValues` was logging the full metadata payload via `console.log`, leaking schema details and bypassing the service's `onLog` mechanism. Replaced with `this.onLog(…, "info")`.

- **`src/model/UpdateColumn.tsx`** — `dbValue` for `MultiSelectPicklist` was returning a comma-separated string. The Dataverse Web API expects an array of integers for multi-select option sets:

```ts
// Before
return this.selectedSelections?.map((s) => s.value).join(","); // "1,2,3"

// After
return this.selectedSelections?.map((s) => parseInt(s.value, 10)); // [1, 2, 3]
```